### PR TITLE
Fix for having an array of attributes

### DIFF
--- a/obs-notify_email/notify_email.pm
+++ b/obs-notify_email/notify_email.pm
@@ -100,6 +100,7 @@ sub notify {
 sub notify_setting {
   my ($self, $project) = @_;
   my ($xml, $attributes);
+  my $value = 0;
 
   $xml = $self->call_obs_api("/source/$project/_attribute/$notify_email_config::notify_attr");
 
@@ -107,7 +108,17 @@ sub notify_setting {
     $attributes = XMLin($xml, KeyAttr => { }, ForceArray =>0);
   }
 
-  return $attributes->{attribute}->{'value'} || 0;
+  if (ref($attributes->{'attribute'}) eq 'ARRAY') {
+    for my $attribute (@{ $attributes->{'attribute'} }) {
+      if ($attribute->{'value'}) {
+        $value = $attribute->{'value'};
+      }
+    }
+  } elsif (ref($attributes->{'attribute'}) eq 'HASH') {
+    $value = $attributes->{attribute}->{'value'};
+  }
+
+  return $value;
 }
 
 sub unique {


### PR DESCRIPTION
In case there are multiple target repositories for a project the api
returns an array of attribute settings:

$ osc api /source/sample_repo/_attribute/B1:notify
<attributes>
  <attribute name="notify" namespace="B1">
    <value>1</value>
  </attribute>
  <attribute name="notify" namespace="B1">
    <value>1</value>
  </attribute>
</attributes>

In this case the notification fails:
rpc failed: 400 remote error: Not a HASH reference at plugins/notify_email.pm l\
ine 113.

As a result the build is orphaned and gets restarted.

Signed-off-by: Jan Blunck jblunck@brocade.com
